### PR TITLE
Update the API used from the extension

### DIFF
--- a/tutorials/seymour-island/task5.md
+++ b/tutorials/seymour-island/task5.md
@@ -37,7 +37,7 @@ for (let index = 0; index < 3; index++) {
 With all your clownfish now collected, next write a program to take your Agent over to the correct drop off point on the pier and use the ``||agent:agent drop items one at a time||`` command to drop all the fish into the bucket.
 
 ```ghost
-agent.dropItemsIndividually(FORWARD, 0, 0)
+agent.dropAllItemsIndividually(FORWARD)
 
 ```
 


### PR DESCRIPTION
This change uses the update API name and parameters from this PR: https://github.com/CausewayDigital/pxt-causeway-digital-extension/commit/4260af9a876a10f4189545cf573cfae73d2e9b8a#diff-534b672fdc2a1739717d78da83ad2378430e0a0f351e8dd52ad5d61b4efb9946

I tested it in the tutorial tool, and it imports the extension nicely now!